### PR TITLE
Self Injection

### DIFF
--- a/lib/pluto.js
+++ b/lib/pluto.js
@@ -127,6 +127,8 @@ function pluto() {
   bind.getAll = getAll
   bind.bootstrap = bootstrap
 
+  bind('plutoBinder').toInstance(bind)
+
   return bind
 }
 

--- a/lib/pluto.js
+++ b/lib/pluto.js
@@ -75,6 +75,7 @@ function pluto() {
 
   function bootstrap() {
     const result = new Map()
+    bind('plutoApp').toInstance(result)
     const promises = []
     for (let name of namesToResolvers.keys()) {
       promises.push(get(name).then((value) => {

--- a/lib/plutoSpec.js
+++ b/lib/plutoSpec.js
@@ -331,3 +331,31 @@ test('injects the binder itself under the name `plutoBinder`', function* (t) {
   const actual = yield bind.get('factory')
   t.is(actual, 'test-data')
 })
+
+test('when bootstrapped, injects the bootstrapped app itself under the name `plutoApp`', function* (t) {
+  class Greeter {
+    constructor(plutoApp) {
+      // Note: the plutoApp Map may not be fully populated yet, since we could
+      // be at any indeterminate part of the bootstrapping process.
+      // Save it for later, but don't go using it yet.
+      this._plutoApp = plutoApp
+    }
+
+    greet() {
+      // By now, the app is fully bootstrapped and the plutoApp Map is safe
+      // to use.
+      const greeting = this._plutoApp.get('greeting')
+      return `${greeting}, World!`
+    }
+  }
+
+  const bind = pluto()
+  bind('greeting').toInstance('Bonjour')
+  bind('greeter').toConstructor(Greeter)
+
+  const app = yield bind.bootstrap()
+
+  const greeter = app.get('greeter')
+  const actual = greeter.greet()
+  t.is(actual, 'Bonjour, World!')
+})

--- a/lib/plutoSpec.js
+++ b/lib/plutoSpec.js
@@ -318,3 +318,16 @@ test('bind.eageryLoadAll executes all factory and constructor functions', functi
   t.truthy(app.get('Constructor') instanceof FakeConstructor)
   t.is(app.get('factory'), 'fake-factory-result')
 })
+
+test('injects the binder itself under the name `plutoBinder`', function* (t) {
+  function fakeFactory(plutoBinder) {
+    return plutoBinder.get('data') // will return a promise
+  }
+
+  const bind = pluto()
+  bind('data').toInstance('test-data')
+  bind('factory').toFactory(fakeFactory)
+
+  const actual = yield bind.get('factory')
+  t.is(actual, 'test-data')
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluto",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Dependency injection that's so small, it almost doesn't count.",
   "homepage": "https://github.com/ecowden/pluto.js",
   "keywords": [


### PR DESCRIPTION
This adds the ability to inject the pluto binder (under `plutoBinder`) and a fully bootstrapped app (under `plutoApp`) within a dependency injected component.

This was requested by @oetjenb. 😎 